### PR TITLE
ci/WS-213 - remove default npm plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
         }
       ],
       "@semantic-release/changelog",
-      "@semantic-release/npm",
       "@semantic-release/github"
     ]
   },


### PR DESCRIPTION
default semantic-release npm plugin is no longer needed

WS-213